### PR TITLE
Add Lodgify-Monday sync service

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,27 @@
-# Lodgify
+# Lodgify Monday Sync Service
+
+Simple Flask service that syncs Lodgify reservations with a Monday.com board.
+
+## Endpoints
+
+- `GET /health` – health check.
+- `GET /lodgify-sync-all?limit=&skip=&debug=` – pull Lodgify bookings and upsert to Monday.
+- `POST /webhook/lodgify` – receive a Lodgify booking webhook and upsert to Monday.
+
+Environment variables:
+
+- `LODGY_API_KEY` – API key for Lodgify.
+- `MONDAY_API_KEY` – API key for Monday.com.
+- `MONDAY_BOARD_ID` – target Monday board ID.
+
+Install dependencies:
+
+```bash
+pip install -r requirements.txt
+```
+
+Run the service:
+
+```bash
+python app.py
+```

--- a/app.py
+++ b/app.py
@@ -1,0 +1,174 @@
+import os
+import logging
+from typing import Any, Dict, Optional
+
+import requests
+from flask import Flask, jsonify, request
+
+from mapping import map_booking_to_columns, RESERVATION_COLUMN, COLUMN_MAP
+
+# Configuration
+LODGY_API_KEY = os.getenv("LODGY_API_KEY", "")
+MONDAY_API_KEY = os.getenv("MONDAY_API_KEY", "")
+MONDAY_BOARD_ID = os.getenv("MONDAY_BOARD_ID", "")
+LODGY_ENDPOINT = "https://api.lodgify.com/v2/reservations/bookings"
+MONDAY_ENDPOINT = "https://api.monday.com/v2"
+
+app = Flask(__name__)
+logging.basicConfig(level=logging.INFO)
+
+def monday_graphql(query: str, variables: Dict[str, Any]) -> Dict[str, Any]:
+    headers = {"Authorization": MONDAY_API_KEY}
+    resp = requests.post(MONDAY_ENDPOINT, json={"query": query, "variables": variables}, headers=headers, timeout=15)
+    if resp.status_code != 200:
+        raise RuntimeError(f"Monday API HTTP {resp.status_code}")
+    data = resp.json()
+    if data.get("errors"):
+        raise RuntimeError(data["errors"][0].get("message"))
+    return data["data"]
+
+
+def lookup_monday_item(reservation_id: str) -> Optional[str]:
+    query = (
+        "query($board_id: ID!, $column_id: String!, $value: String!) { "
+        "items_page_by_column_values(board_id: $board_id, column_id: $column_id, column_value: $value, limit: 1) { "
+        "items { id } } }"
+    )
+    variables = {
+        "board_id": MONDAY_BOARD_ID,
+        "column_id": RESERVATION_COLUMN,
+        "value": reservation_id,
+    }
+    try:
+        data = monday_graphql(query, variables)
+        items = data["items_page_by_column_values"].get("items") or []
+        if items:
+            return items[0]["id"]
+    except RuntimeError as exc:
+        if "Column not found" in str(exc):
+            return None
+        raise
+    return None
+
+
+def create_monday_item(column_values: Dict[str, Any]) -> str:
+    query = (
+        "mutation($board_id: ID!, $item_name: String!, $column_values: JSON!) { "
+        "create_item(board_id: $board_id, group_id: \"topics\", item_name: $item_name, column_values: $column_values) { id } }"
+    )
+    rid = column_values.get(RESERVATION_COLUMN)
+    item_name = f"Reservation {rid}" if rid else "Reservation"
+    variables = {
+        "board_id": MONDAY_BOARD_ID,
+        "item_name": item_name,
+        "column_values": column_values,
+    }
+    data = monday_graphql(query, variables)
+    return data["create_item"]["id"]
+
+
+def update_monday_item(item_id: str, column_values: Dict[str, Any]) -> str:
+    query = (
+        "mutation($item_id: ID!, $board_id: ID!, $column_values: JSON!) { "
+        "change_multiple_column_values(item_id: $item_id, board_id: $board_id, column_values: $column_values) { id } }"
+    )
+    variables = {
+        "item_id": item_id,
+        "board_id": MONDAY_BOARD_ID,
+        "column_values": column_values,
+    }
+    data = monday_graphql(query, variables)
+    return data["change_multiple_column_values"]["id"]
+
+
+def upsert_booking(booking: Dict[str, Any]) -> Dict[str, Any]:
+    columns = map_booking_to_columns(booking)
+    reservation_id = columns.get(RESERVATION_COLUMN)
+    result: Dict[str, Any] = {"reservation_id": reservation_id}
+    try:
+        item_id = None
+        if reservation_id:
+            try:
+                item_id = lookup_monday_item(str(reservation_id))
+            except Exception as exc:
+                logging.error("Lookup failed: %s", exc)
+        if item_id:
+            updated_id = update_monday_item(item_id, columns)
+            logging.info("Updated item %s", updated_id)
+            result.update({"id": updated_id, "action": "updated"})
+        else:
+            new_id = create_monday_item(columns)
+            logging.info("Created item %s", new_id)
+            result.update({"id": new_id, "action": "created"})
+    except Exception as exc:
+        logging.error("Upsert error for %s: %s", reservation_id, exc)
+        result.update({"error": str(exc)})
+    return result
+
+
+def fetch_lodgify_bookings(limit: int = 50, skip: int = 0) -> Dict[str, Any]:
+    params = {"take": limit, "skip": skip}
+    headers = {"X-ApiKey": LODGY_API_KEY}
+    resp = requests.get(LODGY_ENDPOINT, params=params, headers=headers, timeout=15)
+    if resp.status_code == 400:
+        params = {"pageSize": limit, "pageNumber": skip // limit + 1}
+        resp = requests.get(LODGY_ENDPOINT, params=params, headers=headers, timeout=15)
+    resp.raise_for_status()
+    return resp.json()
+
+
+@app.route("/health")
+def health() -> Any:
+    return jsonify({"ok": True, "service": "lodgify-monday-sync", "board_id": MONDAY_BOARD_ID})
+
+
+@app.route("/lodgify-sync-all")
+def lodgify_sync_all() -> Any:
+    limit = int(request.args.get("limit", 50))
+    skip = int(request.args.get("skip", 0))
+    debug = request.args.get("debug") == "1"
+
+    bookings_data = fetch_lodgify_bookings(limit=limit, skip=skip)
+    bookings = bookings_data.get("results") or bookings_data.get("items") or []
+    logging.info("Fetched %d bookings", len(bookings))
+
+    results = []
+    errors = []
+    sample_raw = None
+    sample_mapped = None
+
+    for idx, booking in enumerate(bookings):
+        res = upsert_booking(booking)
+        results.append(res)
+        if res.get("error"):
+            errors.append(res)
+        if debug and sample_raw is None:
+            sample_raw = booking
+            sample_mapped = map_booking_to_columns(booking)
+
+    response: Dict[str, Any] = {"ok": True, "count": len(results), "results": results}
+    if errors:
+        response["errors"] = errors
+    if debug:
+        response["sample"] = {"raw": sample_raw, "mapped": sample_mapped}
+    return jsonify(response)
+
+
+@app.route("/webhook/lodgify", methods=["POST"])
+def webhook_lodgify() -> Any:
+    payload = request.get_json(force=True, silent=True) or {}
+    booking = payload.get("booking") if isinstance(payload, dict) else None
+    if not booking:
+        booking = payload
+    result = upsert_booking(booking)
+    return jsonify({"ok": True, "result": result})
+
+
+@app.errorhandler(Exception)
+def handle_exception(e: Exception):
+    logging.exception("Unhandled error: %s", e)
+    return jsonify({"ok": False, "error": str(e)}), 500
+
+
+if __name__ == "__main__":
+    app.run(host="0.0.0.0", port=int(os.getenv("PORT", "5000")))

--- a/mapping.py
+++ b/mapping.py
@@ -1,0 +1,93 @@
+import re
+from datetime import datetime
+from typing import Any, Dict, Optional
+
+STATUS_MAP = {
+    "confirmed": "Confirmed",
+    "booked": "Confirmed",
+    "pending": "Pending",
+    "paid": "Paid",
+    "cancelled": "Cancelled",
+    "canceled": "Cancelled",
+}
+
+RESERVATION_COLUMN = "text_mkv47vb1"
+COLUMN_MAP = {
+    "unit": "text_mkv49eqm",
+    "email": "email_mkv4mbte",
+    "phone": "phone_mkv4yk8k",
+    "check_in": "date_mkv4npgx",
+    "check_out": "date_mkv46w1t",
+    "total": "numeric_mkv4n3qy",
+    "currency": "text_mkv497t1",
+    "status": "color_mkv4zrs6",
+}
+
+
+def _first(d: Dict[str, Any], *keys: str) -> Optional[Any]:
+    for k in keys:
+        if isinstance(d, dict) and d.get(k) not in (None, ""):
+            return d.get(k)
+    return None
+
+
+def normalize_phone(phone: str) -> Optional[str]:
+    if not phone:
+        return None
+    phone = re.sub(r"[^\d+]", "", phone)
+    if phone.startswith("00"):
+        phone = "+" + phone[2:]
+    if not phone.startswith("+"):
+        return None
+    return phone if len(phone) > 4 else None
+
+
+def parse_date(value: str) -> Optional[str]:
+    if not value:
+        return None
+    value = value.split("T")[0]
+    try:
+        dt = datetime.strptime(value, "%Y-%m-%d")
+        return dt.strftime("%Y-%m-%d")
+    except ValueError:
+        return None
+
+
+def map_booking_to_columns(booking: Dict[str, Any]) -> Dict[str, Any]:
+    guest = booking.get("guest") or booking.get("customer") or {}
+    price = booking.get("price") or {}
+
+    reservation_id = _first(booking, "reservation_id", "id", "reservationId")
+    unit = _first(booking, "unit", "unit_name", "unitName", "rental_name")
+    email = _first(guest, "email")
+    phone = normalize_phone(_first(guest, "phone", "telephone", "mobile"))
+    check_in = parse_date(_first(booking, "check_in", "arrival", "checkIn", "stayArrival"))
+    check_out = parse_date(_first(booking, "check_out", "departure", "checkOut", "stayDeparture"))
+    total = _first(booking, "total", "total_amount", "totalAmount", "price_total") or price.get("total")
+    currency = _first(booking, "currency", "currency_code") or price.get("currency")
+    status_raw = str(_first(booking, "status") or "").lower()
+    status = STATUS_MAP.get(status_raw, "Pending")
+
+    columns: Dict[str, Any] = {}
+    if reservation_id:
+        columns[RESERVATION_COLUMN] = str(reservation_id)
+    if unit:
+        columns[COLUMN_MAP["unit"]] = unit
+    if email:
+        columns[COLUMN_MAP["email"]] = {"email": email, "text": email}
+    if phone:
+        columns[COLUMN_MAP["phone"]] = {"phone": phone}
+    if check_in:
+        columns[COLUMN_MAP["check_in"]] = {"date": check_in}
+    if check_out:
+        columns[COLUMN_MAP["check_out"]] = {"date": check_out}
+    try:
+        if total is not None:
+            columns[COLUMN_MAP["total"]] = float(total)
+    except (TypeError, ValueError):
+        pass
+    if currency:
+        columns[COLUMN_MAP["currency"]] = currency
+    if status:
+        columns[COLUMN_MAP["status"]] = {"label": status}
+    return columns

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+Flask==2.3.3
+requests==2.31.0

--- a/tests/test_mapping.py
+++ b/tests/test_mapping.py
@@ -1,0 +1,47 @@
+import os
+os.environ.setdefault("MONDAY_BOARD_ID", "1")
+
+from mapping import map_booking_to_columns, RESERVATION_COLUMN, COLUMN_MAP
+
+
+def test_map_booking_to_columns_basic():
+    booking = {
+        "id": "ABC123",
+        "unit": "Unit 7",
+        "status": "confirmed",
+        "check_in": "2024-08-01",
+        "check_out": "2024-08-05",
+        "total": "123.45",
+        "currency": "USD",
+        "guest": {"email": "test@example.com", "phone": "+1 (555) 000-1111"},
+    }
+    cols = map_booking_to_columns(booking)
+    assert cols[RESERVATION_COLUMN] == "ABC123"
+    assert cols[COLUMN_MAP["unit"]] == "Unit 7"
+    assert cols[COLUMN_MAP["email"]] == {"email": "test@example.com", "text": "test@example.com"}
+    assert cols[COLUMN_MAP["phone"]] == {"phone": "+15550001111"}
+    assert cols[COLUMN_MAP["check_in"]] == {"date": "2024-08-01"}
+    assert cols[COLUMN_MAP["total"]] == 123.45
+    assert cols[COLUMN_MAP["currency"]] == "USD"
+    assert cols[COLUMN_MAP["status"]] == {"label": "Confirmed"}
+
+
+def test_map_booking_to_columns_edge_cases():
+    booking = {
+        "reservation_id": "XYZ",
+        "check_in": "2024-09-01T15:00:00Z",
+        "total": "abc",
+        "status": "unknown",
+        "guest": {"email": "", "phone": "12345"},
+    }
+    cols = map_booking_to_columns(booking)
+    assert cols[RESERVATION_COLUMN] == "XYZ"
+    # ISO datetime should be truncated to date
+    assert cols[COLUMN_MAP["check_in"]] == {"date": "2024-09-01"}
+    # invalid phone and empty email should be omitted
+    assert COLUMN_MAP["phone"] not in cols
+    assert COLUMN_MAP["email"] not in cols
+    # non-numeric total should be ignored
+    assert COLUMN_MAP["total"] not in cols
+    # unknown status should fall back to Pending
+    assert cols[COLUMN_MAP["status"]] == {"label": "Pending"}


### PR DESCRIPTION
## Summary
- Extract mapping logic to standalone module decoupled from Flask/requests
- Improve date parsing and update tests to import the new mapping module
- Add edge-case tests for mapping including ISO date handling, invalid phone/email omission, numeric total validation, and status fallback
- Pin Flask and Requests versions in requirements

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement Flask==2.3.3 (from versions: none))*
- `python -m py_compile app.py mapping.py tests/test_mapping.py`
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ab59d9402c8326a562a429b9fef726